### PR TITLE
useDebouncedState Hook

### DIFF
--- a/src/hooks/useDebouncedState.ts
+++ b/src/hooks/useDebouncedState.ts
@@ -1,0 +1,21 @@
+import { useCallback, useState } from 'react';
+import { debounce } from 'lodash';
+
+type DebouncedStateSetter<T> = (value: T) => void;
+
+export function useDebouncedState<T>(initialValue: T, delay = 500): [T, DebouncedStateSetter<T>] {
+  const [state, setState] = useState<T>(initialValue);
+
+  const debouncedSetState = useCallback(
+    debounce((value: T) => {
+      setState(value);
+    }, delay),
+    []
+  );
+
+  const handleStateChange: DebouncedStateSetter<T> = (value: T) => {
+    debouncedSetState(value);
+  };
+
+  return [state, handleStateChange];
+}

--- a/src/hooks/useDebouncedState.ts
+++ b/src/hooks/useDebouncedState.ts
@@ -3,7 +3,7 @@ import { debounce } from 'lodash';
 
 type DebouncedStateSetter<T> = (value: T) => void;
 
-export function useDebouncedState<T>(initialValue: T, delay = 500): [T, DebouncedStateSetter<T>] {
+export default function useDebouncedState<T>(initialValue: T, delay = 500): [T, DebouncedStateSetter<T>] {
   const [state, setState] = useState<T>(initialValue);
 
   const debouncedSetState = useCallback(


### PR DESCRIPTION
a simple hook that works like useState:

`import  useDebouncedState  from 'src/hooks/useDebouncedState';

const [debouncedState, setDebouncesState] = useDebouncedState<string>('', 500);

return <p>{debouncedState}</p>`